### PR TITLE
Update entrypoint.sh

### DIFF
--- a/docker/base/entrypoint.sh
+++ b/docker/base/entrypoint.sh
@@ -10,3 +10,6 @@ sudo touch /dev/input/{js0,js1,js2,js3}
 
 #start systemd
 source /sbin/init --log-level=err
+
+# You can use a command like `tail -f /dev/null` to keep the container running.
+tail -f /dev/null


### PR DESCRIPTION
It keeps the container running with tail -f /dev/null at the end, which is necessary to keep the container alive as long as the main process is running.