### PR TITLE
Fix systemd error when booting up

### DIFF
--- a/docker/base/entrypoint.sh
+++ b/docker/base/entrypoint.sh
@@ -19,4 +19,4 @@ sudo mkdir -pm755 /dev/input
 sudo touch /dev/input/{js0,js1,js2,js3}
 
 #start systemd
-source /sbin/init --log-level=err
+exec /sbin/init --log-level=err


### PR DESCRIPTION
Fix error ``/scripts/entrypoint.sh: line 22: source: /sbin/init: cannot execute binary file`` when booting up